### PR TITLE
Feature/move nodes on canvas

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -29,7 +29,6 @@
     [
       "@semantic-release/npm",
       {
-        "npmPublish": false,
         "pkgRoot": "dist/ngx-diagrams",
         "tarballDir": "dist"
       }
@@ -50,7 +49,6 @@
     [
       "@semantic-release/npm",
       {
-        "npmPublish": false,
         "pkgRoot": "dist/ngx-diagrams",
         "tarballDir": "dist"
       }

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ jobs:
         github-token: $GITHUB_TOKEN
         keep-history: true
         local-dir: dist/docs
-        on:
-          tags: true
 
 branches:
   except:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "type": "git",
     "url": "https://github.com/DanielNetzer/ngx-diagrams.git"
   },
-  "private": true,
   "dependencies": {
     "@angular/animations": "~7.2.0",
     "@angular/common": "~7.2.0",


### PR DESCRIPTION
semantic-release should now publish to npm
storybook should now be deployed to gh-pages on new version release